### PR TITLE
Add Gemini flashcard generator endpoint

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -7,6 +7,7 @@ from fastapi.staticfiles import StaticFiles
 
 from app.routes.history import router as history_router
 from app.routes.upload import router as upload_router
+from app.routes.flashcards import router as flashcards_router
 
 
 app = FastAPI(title="Quizly API")
@@ -38,3 +39,4 @@ def health():
 
 app.include_router(history_router, prefix="/api", tags=["History"])
 app.include_router(upload_router, prefix="/api", tags=["Upload"])
+app.include_router(flashcards_router, prefix="/api", tags=["Flashcards"])

--- a/app/routes/flashcards.py
+++ b/app/routes/flashcards.py
@@ -1,0 +1,31 @@
+from pydantic import BaseModel
+from fastapi import APIRouter, HTTPException
+from fastapi.concurrency import run_in_threadpool
+
+from app.services.gemini_service import generate_study_materials
+
+router = APIRouter()
+
+
+class FlashcardRequest(BaseModel):
+    text: str
+
+
+@router.post("/flashcards")
+async def generate_flashcards(payload: FlashcardRequest):
+    text = (payload.text or "").strip()
+
+    if not text:
+        raise HTTPException(status_code=400, detail="Text is required")
+
+    try:
+        materials = await run_in_threadpool(generate_study_materials, text)
+        flashcards = materials.get("flashcards", [])
+
+        return {
+            "success": True,
+            "flashcards": flashcards,
+        }
+
+    except Exception:
+        raise HTTPException(status_code=500, detail="Failed to generate flashcards")


### PR DESCRIPTION
Closes #6

## What I changed
- Added a dedicated FastAPI endpoint for flashcard generation
- Reused the Gemini study materials generation to return flashcards only
- Registered the new route in the main app

## Result
Users can now send text/topic input to `/api/flashcards` and receive AI-generated flashcards.