### PR TITLE
Add .env.example and clean README sections (#44)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,3 @@
+NEXT_PUBLIC_SUPABASE_URL=your_supabase_url
+SUPABASE_SECRET_KEY=your_supabase_secret_key
+GEMINI_API_KEY=your_gemini_api_key

--- a/README.md
+++ b/README.md
@@ -155,10 +155,10 @@ source .venv/bin/activate
 ```bash
 pip install -r requirements.txt
 ```
-### 4. Create a .env file
+### 4. Create a `.env` file
 ```bash
 NEXT_PUBLIC_SUPABASE_URL=your_supabase_url
-NEXT_PUBLIC_SUPABASE_PUBLISHABLE_DEFAULT_KEY=your_supabase_publishable_key
+SUPABASE_SECRET_KEY=your_supabase_secret_key
 GEMINI_API_KEY=your_gemini_api_key
 ```
 ### 5. Run the app (development)
@@ -198,22 +198,20 @@ http://127.0.0.1:8000/
 http://127.0.0.1:8000/health
 
 ---
-## Docker Instructions
-CI/CD Pipeline
+## CI/CD Pipeline
 
 Quizly uses GitHub Actions for CI and Render for deployment.
 
-- CI
+- CI  
 On every push and pull request, the pipeline:
+- checks out the code
+- installs dependencies
+- runs the full pytest suite
+- builds the Docker image
+- starts a container from the built image
+- performs a smoke test against the `/health` endpoint
 
-checks out the code
-installs dependencies
-runs the full pytest suite
-builds the Docker image
-starts a container from the built image
-performs a smoke test against the /health endpoint
-
-- CD
+- CD  
 After successful integration and deployment, the latest version of the application is available on Render at:
 
 https://quizly-whkk.onrender.com/


### PR DESCRIPTION
## Summary
- add `.env.example` with required runtime keys
- align README env setup with current server-side configuration
- remove duplicate/unclear heading and clean CI/CD section formatting

## Test plan
- [x] Verify `.env.example` is tracked (not ignored)
- [ ] Fresh clone follow-through of README setup steps

Closes #44

Made with [Cursor](https://cursor.com)